### PR TITLE
feat: added help target to Makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # November 2025
 
 * Added `make help` and `make coin-help` commands that will print out documentation for each command, grouped by category
+* CDK stack synthesizer now defaults to using the current user's IAM credentials to perform deployments instead of trying to assume a role created by the CDK bootstrap.
 
 # October 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # COIN Shell Release Notes
 
+# November 2025
+
+* Added `make help` and `make coin-help` commands that will print out documentation for each command, grouped by category
+
 # October 2025
 
 * Perform validation of your environmnt configurations either directly or automatically before running a script

--- a/create-app.sh
+++ b/create-app.sh
@@ -958,7 +958,21 @@ create_app () {
     if [[ "$iac" == "terraform" ]]; then
 
         # upgrade-mode should update environment/Makefile, just not root Makefile
-        cat "$makeDir/terraform/Makefile" >> "$envMakeFilePath"
+        # cat "$makeDir/terraform/Makefile" >> "$envMakeFilePath"
+
+        # Put commands from terraform-utils into the "COIN General Utilities" help section
+        # and commands from wizard into the "COIN WIZARDS" help section
+        local generalUtilsStartLine=$(sed -n "/@ COIN General Utilities/=" "$makeDir/Makefile")
+        ((generalUtilsStartLine++)) # Increments line number
+        local wizardsStartLine=$(sed -n "/@ COIN Wizards/=" "$makeDir/Makefile")
+        ((wizardsStartLine++)) # Increments line number
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i "" "${generalUtilsStartLine}r $makeDir/terraform/terraform-utils/Makefile" "$envMakeFilePath"
+            sed -i "" "${wizardsStartLine}r $makeDir/terraform/wizard/Makefile" "$envMakeFilePath"
+        else
+            sed -i "${generalUtilsStartLine}r $makeDir/terraform/terraform-utils/Makefile" "$envMakeFilePath"
+            sed -i "${wizardsStartLine}r $makeDir/terraform/wizard/Makefile" "$envMakeFilePath"
+        fi
 
         if [[ "$coinAppExists" == "n" ]] || [[ "$coinConfigExists" == "n" ]] || [[ "$destructiveUpgrade" == "y" ]]; then
 
@@ -977,7 +991,20 @@ create_app () {
     elif [[ "$iac" == "cdk2" ]]; then
 
         # upgrade-mode should update environment/Makefile, just not root Makefile
-        cat "$makeDir/cdk2/Makefile" >> "$envMakeFilePath"
+
+        # Put commands from cdk-utils into the "COIN General Utilities" help section
+        # and commands from wizard into the "COIN WIZARDS" help section
+        local generalUtilsStartLine=$(sed -n "/@ COIN General Utilities/=" "$makeDir/Makefile")
+        ((generalUtilsStartLine++)) # Increments line number
+        local wizardsStartLine=$(sed -n "/@ COIN Wizards/=" "$makeDir/Makefile")
+        ((wizardsStartLine++)) # Increments line number
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i "" "${generalUtilsStartLine}r $makeDir/cdk2/cdk-utils/Makefile" "$envMakeFilePath"
+            sed -i "" "${wizardsStartLine}r $makeDir/cdk2/wizard/Makefile" "$envMakeFilePath"
+        else
+            sed -i "${generalUtilsStartLine}r $makeDir/cdk2/cdk-utils/Makefile" "$envMakeFilePath"
+            sed -i "${wizardsStartLine}r $makeDir/cdk2/wizard/Makefile" "$envMakeFilePath"
+        fi
 
         if [[ "$coinAppExists" == "n" ]] || [[ "$coinConfigExists" == "n" ]] || [[ "$destructiveUpgrade" == "y" ]]; then
             cat "$rootMakeDir/cdk2/bootstrap/Makefile" >> "$rootEnvMakeFilePath"

--- a/environment/local-command-runner/make/Makefile
+++ b/environment/local-command-runner/make/Makefile
@@ -11,6 +11,12 @@ include $(ENV_PATH)make-env
 list:
 	@LC_ALL=C $(MAKE) -pRrq -f $(firstword $(MAKEFILE_LIST)) : 2>/dev/null | awk -v RS= -F: '/(^|\n)# Files(\n|$$)/,/(^|\n)# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' | sort | egrep -v -e '^[^[:alnum:]]' -e '^$@$$'
 
+# Show COIN Shell commands and descriptions, grouped by section
+csh:
+	@awk 'BEGIN {FS = ": .*##"; printf "\nUsage:\n make \033[36m<target>\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+(\\:[$$()% 0-9a-zA-Z_-]+)*:.*?##/ { gsub(/\\:/,":", $$1); printf " \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(word 2,$(MAKEFILE_LIST))
+
+##@ COIN Wizards
+
 # Wizard to create a new or update an existing application environment
 # Takes an optional "f" parameter if you want to pass an environment
 # JSON file in that has all the settings. Passing in a JSON file puts
@@ -19,81 +25,119 @@ list:
 #   make create-environment
 #   OR
 #   make create-environment f=<pathToEnvironmentJsonFile>
-create-environment:
+create-environment: ## Create a new set of environment configs
 	@$(ENV_PATH)create-app-environment.sh "$(f)"
 
 # Simple create-environment shortcut
-ce:
+ce: ## Create a new set of environment configs
 	@$(MAKE) create-environment f="$(f)"
 
 # Wizard to delete an application environment
-delete-environment:
+delete-environment: ## Delete a set of environment configs
 	@$(ENV_PATH)delete-app-environment.sh
 
 # Simple delete-environment shortcut
-de: delete-environment
+de: delete-environment ## Delete a set of environment configs
+
+# Create a new root Infrastructure as Code module based on the environment/iac-module-template
+create_iac_root_module: ## Create a new IaC root module
+	@$(ENV_PATH)create-iac-module.sh
+
+# Simple create_iac_root_module shortcut
+cim: create_iac_root_module ## Create a new IaC root module
+
+# extract-deliverable wizard that will extract application files that we want to share into a separate directory
+# Takes an optional "b" parameter if you want to specifiy the branch to clone
+# usage: 
+#   make extract-deliverable
+#   OR
+#   make extract-deliverable b=<myBranchName>
+extract-deliverable: ## Create a customized export of this project
+	@$(ENV_PATH)extract-deliverable.sh "$(b)"
+
+# Simple extract-deliverable shortcut
+exd: extract-deliverable ## Create a customized export of this project
+
+##@ COIN Environments
 
 # Presents choice of which local environment to set as the current one
-switch-current-environment:
+switch-current-environment: ## Select an environmnt to use
 	@$(ENV_PATH)utility-functions.sh switch_local_environment
 
 # Simple switch-current-environment shortcut
-sce: switch-current-environment
+sce: switch-current-environment ## Select an environmnt to use
 
 # Print the current local environment
-get-current-environment: 
+get-current-environment: ## Print the name of the current environment
 	@$(ENV_PATH)utility-functions.sh get_current_env
 
 # Simple get-current-environment shortcut
-gce: get-current-environment
+gce: get-current-environment ## Print the name of the current environment
 
 # Print the current local environments
-list-local-environments: 
+list-local-environments: ## List the environment names
 	@$(ENV_PATH)utility-functions.sh get_local_environment_names
 
 # Simple list-local-environments shortcut
-lle: list-local-environments
+lle: list-local-environments ## List the environment names
 
 # Print the current remote environments
-list-remote-environments: 
+list-remote-environments: ## List the remote environment names
 	@$(ENV_PATH)utility-functions.sh get_remote_environment_names
 
 # Simple list-remote-environments shortcut
-lre: list-remote-environments
+lre: list-remote-environments ## List the remote environment names
 
 # Print all environment setting name-value pairs for easy confirmation
 # of whether your environment is configured correctly
-print-current-environment:
+print-current-environment: ## Print the current environment settings
 	@$(ENV_PATH)utility-functions.sh print_current_environment
 
 # Simple print-current-environment shortcut
-pce: print-current-environment
+pce: print-current-environment ## Print the current environment settings
 
 # Print a success message if the current environment settings are valid
 # or log an error and exit if they are not valid
-validate-current-environment:
-    @$(ENV_PATH)utility-functions.sh validate_current_environment
+validate-current-environment: ## Validate the current environment settings
+	@$(ENV_PATH)utility-functions.sh validate_current_environment
  
 # Simple validate-current-environment shortcut
-vce: validate-current-environment
+vce: validate-current-environment ## Validate the current environment settings
 
 # Get current COIN environment variable exports to paste into your shell
-export-current-environment:  ## Get current COIN environment variable exports to paste into your shell (alias: ece)
+export-current-environment:  ## Get current COIN environment variable exports to paste into your shell
 	@$(ENV_PATH)utility-functions.sh echo_export_local_app_env_vars
 
 # Simple export-current-environment shortcut
-ece: export-current-environment
+ece: export-current-environment ## Get current COIN environment variable exports to paste into your shell
+
+# Presents choice of remote environments to import and set as the current one
+pull-env-vars: ## Choose a remote environment to download into a local JSON file
+	@$(ENV_PATH)utility-functions.sh pull_env_vars
+
+# Save off local environment variable settings to a remote store e.g. SSM or GitLab.
+# This is useful to make it so that your team members or a CICD pipeline can reference
+# environment variable values
+# Takes an optional "gitRepoToken" parameter if you want to specifiy the git repository token
+# usage: 
+#   make push-env-vars
+#   OR
+#   make push-env-vars gitRepoToken=<myToken>
+push-env-vars: ## Saves environment variables onto a remote store
+	@$(ENV_PATH)utility-functions.sh push_env_vars "$(gitRepoToken)"
+
+##@ COIN File Template Utilities
 
 # Resolve placeholders in a file and print the result to the console
 # usage: make print-resolved-template-file f=<filePath>
-print-resolved-template-file:
+print-resolved-template-file: ## Resolve placeholders in a file and print the result to the console
 	@echo ""
 	@echo "Note: set \"DYNAMIC_RESOLUTION\" environment variable to \"y\" to enable dynamic resolution"
 	@echo ""
 	@$(ENV_PATH)utility-functions.sh print_resolved_placeholders "$(f)"
 
 # Simple print-resolved-template-file shortcut
-prt:
+prt: ## Resolve placeholders in a file and print the result to the console
 	@echo ""
 	@echo "Note: set \"DYNAMIC_RESOLUTION\" environment variable to \"y\" to enable dynamic resolution"
 	@echo ""
@@ -107,11 +151,11 @@ prt:
 #   make list-code-template-files
 #   OR
 #   make list-code-template-files d=<pathToDirectory>
-list-code-template-files:
+list-code-template-files: ## Prints the names of all application code files that contain environment variable
 	@$(ENV_PATH)utility-functions.sh list_code_template_files "$(d)"
 
 # Simple list-code-template-files shortcut
-lctf: 
+lctf: ## Prints the names of all application code files that contain environment variable
 	@$(MAKE) list-code-template-files
 
 # Prints the names of all application files that contain environment placeholders.
@@ -121,20 +165,20 @@ lctf:
 #   make list-template-files
 #   OR
 #   make list-template-files d=<pathToDirectory>
-list-template-files:
+list-template-files: ## Prints the names of all application files that contain environment placeholders.
 	@$(ENV_PATH)utility-functions.sh get_template_files "$(d)"
 
 # Simple list-template-files shortcut
-ltf: 
+ltf: ## Prints the names of all application files that contain environment placeholders.
 	@$(MAKE) list-template-files d="$(d)"
 
 # Validates all application templates to ensure that all placeholders
 # in all templates can be successfully resolved
-validate-template-files:
+validate-template-files: ## Validates all application template files
 	@$(ENV_PATH)utility-functions.sh resolve_template_files "dryRun"
 
 # Simple validate-template-files shortcut
-vtf: validate-template-files
+vtf: validate-template-files ## Validates all application template files
 
 # Resolves placeholders in all application template files and
 # overwrites the files with the resolved content
@@ -145,11 +189,11 @@ vtf: validate-template-files
 #   make resolve-template-files
 #   OR
 #   make resolve-template-files d=<pathToDirectory>
-resolve-template-files:
+resolve-template-files: ## Resolves placeholders in all application template files
 	@$(ENV_PATH)utility-functions.sh resolve_template_files "" "$(d)"
 
 # Simple resolve-template-files shortcut
-rtf: $(MAKE) resolve-template-files
+rtf: $(MAKE) resolve-template-files ## Resolves placeholders in all application template files
 
 # Resolves placeholders in all application template files and
 # overwrites the files with the resolved content
@@ -162,11 +206,11 @@ rtf: $(MAKE) resolve-template-files
 #   make backup-resolve-template-files
 #   OR
 #   make backup-resolve-template-files d=<pathToDirectory>
-backup-resolve-template-files:
+backup-resolve-template-files: ## Resolves placeholders in all application template files - reversible
 	@$(ENV_PATH)utility-functions.sh resolve_template_files "backup" "$(d)"
 
 # Simple backup-resolve-template-files shortcut
-brtf: $(MAKE) backup-resolve-template-files
+brtf: $(MAKE) backup-resolve-template-files ## Resolves placeholders in all application template files - reversible
 
 # Restores template file backups. This serves as an "undo" for the
 # files that were changed by "resolve-template-files"
@@ -176,97 +220,69 @@ brtf: $(MAKE) backup-resolve-template-files
 #   make restore-backup-files
 #   OR
 #   make restore-backup-files d=<pathToDirectory>
-restore-backup-files:
+restore-backup-files: ## Restore placeholders in all application template files
 	@$(ENV_PATH)utility-functions.sh restore_template_files "$(d)"
 
 # Simple restore-backup-files shortcut
-rbf: 
+rbf: ## Restore placeholders in all application template files
 	$(MAKE) restore-backup-files
 
-# extract-deliverable wizard that will extract application files that we want to share into a separate directory
-# Takes an optional "b" parameter if you want to specifiy the branch to clone
-# usage: 
-#   make extract-deliverable
-#   OR
-#   make extract-deliverable b=<myBranchName>
-extract-deliverable:
-	@$(ENV_PATH)extract-deliverable.sh "$(b)"
-
-# Simple extract-deliverable shortcut
-exd: extract-deliverable
-
-# Presents choice of remote environments to import and set as the current one
-pull-env-vars:
-	@$(ENV_PATH)utility-functions.sh pull_env_vars
-
-# Save off local environment variable settings to a remote store e.g. SSM or GitLab.
-# This is useful to make it so that your team members or a CICD pipeline can reference
-# environment variable values
-# Takes an optional "gitRepoToken" parameter if you want to specifiy the git repository token
-# usage: 
-#   make push-env-vars
-#   OR
-#   make push-env-vars gitRepoToken=<myToken>
-push-env-vars:
-	@$(ENV_PATH)utility-functions.sh push_env_vars "$(gitRepoToken)"
+##@ COIN AWS Utilities
 
 # Prints a table of CloudTrail logs for IAM permission denied events
 # over a date range. Useful for debugging IAM role permissions errors.
-list-auth-errors:
+list-auth-errors: ## Prints a table of CloudTrail logs for IAM permission denied events
 	@$(ENV_PATH)utility-functions.sh print_auth_errors
 
 # Simple list-auth-errors shortcut
-lae: list-auth-errors
+lae: list-auth-errors ## Prints a table of CloudTrail logs for IAM permission denied events
+
+# Print who you are logged in as for the AWS CLI - this is influenced by use of environment/.cli-profiles.json
+get-caller-identity: ## Print who you are logged in as for the AWS CLI
+	@$(ENV_PATH)utility-functions.sh get_caller_identity
+
+# Simple get-caller-identity shortcut
+gci: get-caller-identity ## Print who you are logged in as for the AWS CLI
+
+# Log in to the AWS CLI with SSO using the profile for the current environment
+aws-sso-login: ## AWS CLI SSO log in with the profile for the current environment
+	@$(ENV_PATH)utility-functions.sh aws_sso_login
+
+# Simple aws-sso-login shortcut
+asl: aws-sso-login ## AWS CLI SSO log in with the profile for the current environment
+
+##@ COIN General Utilities
 
 # Execute a utility-function on the current environment
 # If you do not supply the "f" argument, the utility function names will be printed out
 # usage: make util f=<functionName>
-util:
+util: ## Execute a utility-function on the current environment
 	@echo "Current environment is \"$(ENV_NAME)\""
 	$(ENV_PATH)utility-functions.sh "$(f)"
 
-# Create a new root Infrastructure as Code module based on the environment/iac-module-template
-create_iac_root_module:
-	@$(ENV_PATH)create-iac-module.sh
-
-# Simple create_iac_root_module shortcut
-cim: create_iac_root_module
-
-# Print who you are logged in as for the AWS CLI - this is influenced by use of environment/.cli-profiles.json
-get-caller-identity:
-	@$(ENV_PATH)utility-functions.sh get_caller_identity
-
-# Simple get-caller-identity shortcut
-gci: get-caller-identity
-
-# Log in to the AWS CLI with SSO using the profile for the current environment
-aws-sso-login:
-	@$(ENV_PATH)utility-functions.sh aws_sso_login
-
-# Simple aws-sso-login shortcut
-asl: aws-sso-login
+##@ COIN Upgrade
 
 # Print the configurations for upgrading the application to the latest standards
-print-upgrade-configs:
+print-upgrade-configs: ## Print the configurations for upgrading COIN for this app
 	$(ENV_PATH)utility-functions.sh get_coin_upgrade_configs
 
 # Simple print-upgrade-configs shortcut
-puc: print-upgrade-configs
+puc: print-upgrade-configs ## Print the configurations for upgrading COIN for this app
 
 # Upgrade this application to use the latest COIN files
-upgrade-coin:
+upgrade-coin: ## Upgrade this app to the latest version of COIN Shell
 	$(ENV_PATH)utility-functions.sh upgrade_coin 
 
 # Simple upgrade-coin shortcut
-uc: upgrade-coin
+uc: upgrade-coin ## Upgrade this app to the latest version of COIN Shell
 
 # Upgrade (in destructive mode) this application to use the latest COIN files.
 # In destructive mode, the upgrade will include files COIN may have changed but that
 # application developers may have also changed. Developers will need to perform a 
 # diff on the upgrade changes and undo any changes made during the upgrade that they
 # do not want
-upgrade-coin-destructive:
+upgrade-coin-destructive: ## Upgrade this app to the latest version of COIN Shell (destructive)
 	$(ENV_PATH)utility-functions.sh upgrade_coin "destructive"
 
 # Simple upgrade-coin-destructive shortcut
-ucd: upgrade-coin-destructive
+ucd: upgrade-coin-destructive ## Upgrade this app to the latest version of COIN Shell (destructive)

--- a/environment/local-command-runner/make/cdk2/cdk-utils/Makefile
+++ b/environment/local-command-runner/make/cdk2/cdk-utils/Makefile
@@ -1,15 +1,8 @@
-
-# Start wizard that will auto-generate IaC deployment instructions
-generate-deployment-instructions:
-	@$(ENV_PATH)generate-deployment-instructions.sh "$(b)"
-
-# Simple generate-deployment-instructions shortcut
-gdi: generate-deployment-instructions
-
 # Sets environment variables, then executes any CDK command that you supply
 # usage:
 # 	make runcdk m=<my-module-name> c="<my CDK command>"
 # example:
 # 	make runcdk m=COIN_IAC_FIRST_MODULE_PLACEHOLDER c="cdk synth STACK_ID --exclusively"
-runcdk:
+runcdk: ## Run arbitrary CDK command against the current environment
 	$(ENV_PATH)utility-functions.sh exec_cdk_command_for_env $(m) "$(c)"
+

--- a/environment/local-command-runner/make/cdk2/cicd/Makefile
+++ b/environment/local-command-runner/make/cdk2/cicd/Makefile
@@ -1,10 +1,10 @@
 
 # cicd: Resolves all environment variables in template files, executes "cdk deploy" 
 # for the cicd module, then restores template files to their original content
-deploy-cicd:
+deploy-cicd: ## Deploys the cicd module
 	$(ENV_PATH)utility-functions.sh exec_cdk_for_env cicd
 
 # cicd: Resolves all environment variables in template files, executes "cdk destroy"
 # for the cicd module, then restores template files to their original content
-destroy-cicd:
+destroy-cicd: ## Destroys the cicd module
 	CDK_MODE=destroy $(ENV_PATH)utility-functions.sh exec_cdk_for_env cicd

--- a/environment/local-command-runner/make/cdk2/firstIacModule/Makefile
+++ b/environment/local-command-runner/make/cdk2/firstIacModule/Makefile
@@ -6,7 +6,7 @@
 #   make diff-COIN_IAC_FIRST_MODULE_PLACEHOLDER
 #   OR
 #   make diff-COIN_IAC_FIRST_MODULE_PLACEHOLDER args="myStackId --exclusively"
-diff-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
+diff-COIN_IAC_FIRST_MODULE_PLACEHOLDER: ## CDK diff on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module
 	CDK_MODE=diff $(ENV_PATH)utility-functions.sh exec_cdk_for_env COIN_IAC_FIRST_MODULE_PLACEHOLDER "$(args)"
 
 # Resolves all environment variables and executes "cdk deploy" 
@@ -16,7 +16,7 @@ diff-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
 #   make deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
 #   OR
 #   make deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER args="myStackId --exclusively"
-deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
+deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER: ## CDK deploy on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module
 	$(ENV_PATH)utility-functions.sh exec_cdk_for_env COIN_IAC_FIRST_MODULE_PLACEHOLDER "$(args)"
 
 # Same as deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER but targets the secondary region instead of the primary region
@@ -25,7 +25,7 @@ deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
 #   make deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER-secondary-region
 #   OR
 #   make deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER-secondary-region args="myStackId --exclusively"
-deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER-secondary-region:
+deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER-secondary-region: ## CDK deploy on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module (secondary region)
 	COIN_OVERRIDE_AWS_DEFAULT_REGION=$(AWS_SECONDARY_REGION) $(ENV_PATH)utility-functions.sh exec_cdk_for_env COIN_IAC_FIRST_MODULE_PLACEHOLDER "$(args)"
 
 # Resolves all environment variables and executes "cdk destroy"
@@ -35,11 +35,11 @@ deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER-secondary-region:
 #   make destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
 #   OR
 #   make destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER args="myStackId --exclusively"
-destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
+destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER: ## CDK destroy on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module
 	CDK_MODE=destroy $(ENV_PATH)utility-functions.sh exec_cdk_for_env COIN_IAC_FIRST_MODULE_PLACEHOLDER "$(args)"
 
 # Deploy all targets in the correct order
-deploy-all: deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
+deploy-all: deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER ## Deploy all targets in the correct order
 
 # Destroy all targets in the correct order
-destroy-all: destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
+destroy-all: destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER ## Destroy all targets in the correct order

--- a/environment/local-command-runner/make/cdk2/wizard/Makefile
+++ b/environment/local-command-runner/make/cdk2/wizard/Makefile
@@ -1,0 +1,7 @@
+# Start wizard that will auto-generate IaC deployment instructions
+generate-deployment-instructions: ## Wizard to auto-generate IaC deployment instructions
+	@$(ENV_PATH)generate-deployment-instructions.sh "$(b)"
+
+# Simple generate-deployment-instructions shortcut
+gdi: generate-deployment-instructions ## Wizard to auto-generate IaC deployment instructions
+

--- a/environment/local-command-runner/make/cicd/Makefile
+++ b/environment/local-command-runner/make/cicd/Makefile
@@ -1,6 +1,6 @@
 
-deploy-cicd:
+deploy-cicd: ## Deploy the CICD module
 	@$(ENV_PATH)utility-functions.sh exec_cf_for_env cicd
 
-destroy-cicd:
+destroy-cicd: ## Destroy the CICD module
 	@$(ENV_PATH)utility-functions.sh destroy_root_cf_stack_by_name cicd

--- a/environment/local-command-runner/make/cloudformation/Makefile
+++ b/environment/local-command-runner/make/cloudformation/Makefile
@@ -1,13 +1,13 @@
 
 
-deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
+deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER: ## CF deploy on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module
 	@$(ENV_PATH)utility-functions.sh exec_cf_for_env COIN_IAC_FIRST_MODULE_PLACEHOLDER
 
-destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER:
+destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER: ## CF destroy on the COIN_IAC_FIRST_MODULE_PLACEHOLDER module
 	@$(ENV_PATH)utility-functions.sh destroy_root_cf_stack_by_name COIN_IAC_FIRST_MODULE_PLACEHOLDER
 
 # Deploy all targets in the correct order
-deploy-all: deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
+deploy-all: deploy-COIN_IAC_FIRST_MODULE_PLACEHOLDER ## Deploy all targets in the correct order
 
 # Destroy all targets in the correct order
-destroy-all: destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER
+destroy-all: destroy-COIN_IAC_FIRST_MODULE_PLACEHOLDER ## Destroy all targets in the correct order

--- a/environment/local-command-runner/make/terraform/bootstrap/cross-region-replication/Makefile
+++ b/environment/local-command-runner/make/terraform/bootstrap/cross-region-replication/Makefile
@@ -1,13 +1,13 @@
 
 # Deploys the Terraform back end CloudFormation stack
-deploy-tf-backend-cf-stack:
+deploy-tf-backend-cf-stack: ## Deploys the Terraform back end CloudFormation stack
 	@$(ENV_PATH)utility-functions.sh deploy_tf_backend_cf_stack "$(AWS_PRIMARY_REGION)"
 	@$(ENV_PATH)utility-functions.sh deploy_tf_backend_cf_stack "$(AWS_SECONDARY_REGION)" "parameters-secondary.json"
 	@$(ENV_PATH)utility-functions.sh deploy_tf_backend_cf_stack "$(AWS_PRIMARY_REGION)" "parameters-crr.json"
 
 # Destroys the Terraform back end CloudFormation stack and deletes Terraform
 # state files
-destroy-tf-backend-cf-stack:
+destroy-tf-backend-cf-stack: ## Destroy Terraform back end and state files
 	@$(ENV_PATH)../build-script/empty-s3.sh empty_s3_bucket_by_name "$(TF_S3_BACKEND_NAME)-$(AWS_ACCOUNT_ID)-$(AWS_PRIMARY_REGION)"
 	@$(ENV_PATH)utility-functions.sh destroy_tf_backend_cf_stack "$(AWS_PRIMARY_REGION)"
 	@$(ENV_PATH)../build-script/empty-s3.sh empty_s3_bucket_by_name "$(TF_S3_BACKEND_NAME)-$(AWS_ACCOUNT_ID)-$(AWS_SECONDARY_REGION)"

--- a/environment/local-command-runner/make/terraform/bootstrap/single-region/Makefile
+++ b/environment/local-command-runner/make/terraform/bootstrap/single-region/Makefile
@@ -1,10 +1,10 @@
 
 # Deploys the Terraform back end CloudFormation stack
-deploy-tf-backend-cf-stack:
+deploy-tf-backend-cf-stack: ## Deploys the Terraform back end CloudFormation stack
 	@$(ENV_PATH)utility-functions.sh deploy_tf_backend_cf_stack "$(AWS_DEFAULT_REGION)"
 
 # Destroys the Terraform back end CloudFormation stack and deletes Terraform
 # state files
-destroy-tf-backend-cf-stack:
+destroy-tf-backend-cf-stack: ## Destroy Terraform back end and state files
 	@$(ENV_PATH)../build-script/empty-s3.sh empty_s3_bucket_by_name "$(TF_S3_BACKEND_NAME)-$(AWS_ACCOUNT_ID)-$(AWS_DEFAULT_REGION)"
 	@$(ENV_PATH)utility-functions.sh destroy_tf_backend_cf_stack "$(AWS_DEFAULT_REGION)"

--- a/environment/local-command-runner/make/terraform/cicd/Makefile
+++ b/environment/local-command-runner/make/terraform/cicd/Makefile
@@ -1,10 +1,10 @@
 
 # cicd: Resolves all environment variables in template files, executes "terraform apply" 
 # for the cicd module, then restores template files to their original content
-deploy-cicd:
+deploy-cicd: ## Deploy the cicd module
 	$(ENV_PATH)utility-functions.sh exec_tf_for_env cicd
 
 # cicd: Resolves all environment variables in template files, executes "terraform destroy"
 # for the cicd module, then restores template files to their original content
-destroy-cicd:
+destroy-cicd: ## Destroy the cicd module
 	TF_MODE=destroy $(ENV_PATH)utility-functions.sh exec_tf_for_env cicd

--- a/environment/local-command-runner/make/terraform/terraform-utils/Makefile
+++ b/environment/local-command-runner/make/terraform/terraform-utils/Makefile
@@ -1,12 +1,3 @@
-
-
-# Start wizard that will auto-generate IaC deployment instructions
-generate-deployment-instructions:
-	@$(ENV_PATH)generate-deployment-instructions.sh "$(b)"
-
-# Simple generate-deployment-instructions shortcut
-gdi: generate-deployment-instructions
-
 # Resolves all environment variables in template files, executes any terraform command that you 
 # supply, then restores template files to their original content
 # Note: to see a list of root Terraform module names, run 'make list-tf-modules'
@@ -14,11 +5,11 @@ gdi: generate-deployment-instructions
 # 	make tf m=<my-module-name> c="<my Terraform command>"
 # example:
 # 	make tf m=my-module-name c="terraform init"
-tf:
+tf:  ## Run arbitrary Terraform command against the current environment
 	$(ENV_PATH)utility-functions.sh exec_tf_command_for_env $(m) "$(c)"
 
 # Print out the names of all of this project's root Terraform modules
-list-tf-modules:
+list-tf-modules:  ## Print Terraform root module names
 	$(ENV_PATH)utility-functions.sh print_root_terraform_modules
 
 # Runs checkov scan against a root Terraform module
@@ -27,9 +18,10 @@ list-tf-modules:
 # 	make tf m=<my-module-name>
 # example:
 # 	make tf m=my-module-name
-checkov:
+checkov:  ## Run checkov scan against a root Terraform module
 	$(ENV_PATH)utility-functions.sh exec_checkov $(m)
 
 # Runs checkov scan against all root Terraform modules
-checkov-all:
+checkov-all:  ## Run checkov scan against all root Terraform modules
 	$(ENV_PATH)utility-functions.sh exec_checkov_all
+

--- a/environment/local-command-runner/make/terraform/wizard/Makefile
+++ b/environment/local-command-runner/make/terraform/wizard/Makefile
@@ -1,0 +1,7 @@
+# Start wizard that will auto-generate IaC deployment instructions
+generate-deployment-instructions:  ## Wizard to auto-generate IaC deployment instructions
+	@$(ENV_PATH)generate-deployment-instructions.sh "$(b)"
+
+# Simple generate-deployment-instructions shortcut
+gdi: generate-deployment-instructions  ## Wizard to auto-generate IaC deployment instructions
+

--- a/iac/cdk2/roots/iac-module-template/package.json
+++ b/iac/cdk2/roots/iac-module-template/package.json
@@ -17,15 +17,15 @@
   "devDependencies": {
     "@types/jest": "29.5.14",
     "@types/node": "22.13.13",
-    "aws-cdk": "2.1018.1",
+    "aws-cdk": "2.1031.1",
     "jest": "29.7.0",
     "ts-jest": "29.3.0",
     "ts-node": "10.9.2",
     "typescript": "5.8.2"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.201.0",
-    "cdk-nag": "2.36.21",
+    "aws-cdk-lib": "2.222.0",
+    "cdk-nag": "2.37.55",
     "constructs": "10.4.2",
     "source-map-support": "0.5.21"
   }

--- a/iac/cdk2/roots/iac-module-template/src/app.ts
+++ b/iac/cdk2/roots/iac-module-template/src/app.ts
@@ -27,7 +27,8 @@ async function main() {
 
     new ###COIN_IAC_MOD_CAMELCASE###Stack(app, `${config.appName}-${config.envName}-###COIN_IAC_MOD_SPINALCASE###`, {
         config,
-        env: { account: config.awsAccountId, region: config.awsDefaultRegion }
+        env: { account: config.awsAccountId, region: config.awsDefaultRegion },
+        synthesizer: config.stackSynthesizer,
     });
 
     app.synth();

--- a/iac/cdk2/roots/iac-module-template/src/utils/config.ts
+++ b/iac/cdk2/roots/iac-module-template/src/utils/config.ts
@@ -1,9 +1,15 @@
+import * as cdk from "aws-cdk-lib";
 
 export interface AppConfig {
     readonly appName: string;
     readonly envName: string;
     readonly awsAccountId: string;
     readonly awsDefaultRegion: string;
+
+    /**
+     * Synthesizer to use for CDK stacks.
+     */
+    readonly stackSynthesizer: cdk.IStackSynthesizer;
 }
 
 export async function getConfig(): Promise<AppConfig> {
@@ -13,6 +19,13 @@ export async function getConfig(): Promise<AppConfig> {
         envName: process.env.ENV_NAME as string,
         awsAccountId: process.env.AWS_ACCOUNT_ID as string,
         awsDefaultRegion: process.env.AWS_DEFAULT_REGION as string,
+
+        /*
+         * See https://docs.aws.amazon.com/cdk/v2/guide/configure-synth.html
+         * cdk.CliCredentialsStackSynthesizer - Instead of assuming the CDK bootstrap deployment roles, all stack operations will be performed using the CLI's current credentials.
+         * cdk.DefaultStackSynthesizer - attempts to assume CDK bootstrap IAM roles for performing deployments
+        */
+        stackSynthesizer: new cdk.CliCredentialsStackSynthesizer(),
     };
     return config;
 }

--- a/project-root/local-command-runner/make/Makefile
+++ b/project-root/local-command-runner/make/Makefile
@@ -1,2 +1,10 @@
 -include environment/Makefile
 export
+
+##@ General
+help: ## Show help message
+	@awk 'BEGIN {FS = ": .*##"; printf "\nUsage:\n make \033[36m<target>\033[0m\n"} /^[$$()% 0-9a-zA-Z_-]+(\\:[$$()% 0-9a-zA-Z_-]+)*:.*?##/ { gsub(/\\:/,":", $$1); printf " \033[36m%-30s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(firstword $(MAKEFILE_LIST))
+
+coin-help: csh ## Show COIN Shell help message
+
+##@ App


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a "help" target to the Makefile that will print out what each Make target does. The help is organized by category. 
Also, change the default CDK stack synthesizer to use the user's current CLI credentials instead of attempting to assume roles from the CDK bootstrap stack

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
